### PR TITLE
add init parameter for forwarded url header

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ example: someproxy,someproxy1
 
 ### blacklist
 
+### forwardedURLHeader
+Important for servers behind reverse proxy that need the public url to be used for pre-rendering.
+We usually set the original url in an http header which is added by the reverse proxy (similar to the more standard `x-forwarded-proto` and `x-forwarded-for`)
 
 ### Using your own prerender service
 

--- a/src/main/java/com/github/greengerong/PreRenderSEOFilter.java
+++ b/src/main/java/com/github/greengerong/PreRenderSEOFilter.java
@@ -207,14 +207,23 @@ public class PreRenderSEOFilter implements Filter {
         }
     }
 
+    private String getRequestURL(HttpServletRequest request) {
+        if (prerenderConfig.getForwardedURLHeader() != null) {
+            String url = request.getHeader(prerenderConfig.getForwardedURLHeader());
+            if (url != null) {
+                return url;
+            }
+        }
+        return request.getRequestURL().toString();
+    }
+
     private String getFullUrl(HttpServletRequest request) {
-        final StringBuffer url = request.getRequestURL();
+        final String url = getRequestURL(request);
         final String queryString = request.getQueryString();
         if (queryString != null) {
-            url.append('?');
-            url.append(queryString);
+            return url + '?' + queryString;
         }
-        return url.toString();
+        return url;
     }
 
     @Override
@@ -229,7 +238,7 @@ public class PreRenderSEOFilter implements Filter {
 
     private boolean shouldShowPrerenderedPage(HttpServletRequest request) throws URISyntaxException {
         final String userAgent = request.getHeader("User-Agent");
-        final String url = request.getRequestURL().toString();
+        final String url = getRequestURL(request);
         final String referer = request.getHeader("Referer");
 
         log.trace("checking request for " + url + " from User-Agent " + userAgent + " and referer " + referer);

--- a/src/main/java/com/github/greengerong/PrerenderConfig.java
+++ b/src/main/java/com/github/greengerong/PrerenderConfig.java
@@ -53,6 +53,10 @@ public class PrerenderConfig {
         return filterConfig.getInitParameter("prerenderToken");
     }
 
+    public String getForwardedURLHeader() {
+        return filterConfig.getInitParameter("forwardedURLHeader");
+    }
+
     public List<String> getCrawlerUserAgents() {
         List<String> crawlerUserAgents = Lists.newArrayList("googlebot", "yahoo", "bingbot", "baiduspider",
                 "facebookexternalhit", "twitterbot", "rogerbot", "linkedinbot", "embedly");


### PR DESCRIPTION
important for servers behind reverse proxy that need the public url to be used for pre-rendering. we usually set the original url in an http header which is added by the reverse proxy (similar to the more standard x-forwarded-proto and x-forwarded-for)
