### PR TITLE
Fix #11: add support for prerender-status-code

### DIFF
--- a/src/main/java/com/github/greengerong/PreRenderSEOFilter.java
+++ b/src/main/java/com/github/greengerong/PreRenderSEOFilter.java
@@ -88,6 +88,7 @@ public class PreRenderSEOFilter implements Filter {
 
         try {
             proxyResponse = httpClient.execute(getMethod);
+            response.setStatus(proxyResponse.getStatusLine().getStatusCode());
             copyResponseHeaders(proxyResponse, response);
             final String html = copyResponseEntity(proxyResponse, response);
             afterRender(request, proxyResponse, html);

--- a/src/test/java/com/github/greengerong/PreRenderSEOFilterTest.java
+++ b/src/test/java/com/github/greengerong/PreRenderSEOFilterTest.java
@@ -232,6 +232,7 @@ public class PreRenderSEOFilterTest {
         //then
         verify(httpClient).execute(httpGet);
         verify(filterChain, never()).doFilter(servletRequest, servletResponse);
+        verify(servletResponse).setStatus(NOT_FOUND);
     }
 
 


### PR DESCRIPTION
The API can return a non-200 response - that's a feature, so it's incorrect to pass it on to the chain in such a case.

See: https://prerender.io/getting-started#404s

Fixes #11
