### PR TITLE
Added .xml in exclution list.

### DIFF
--- a/src/main/java/com/github/greengerong/PrerenderConfig.java
+++ b/src/main/java/com/github/greengerong/PrerenderConfig.java
@@ -88,7 +88,7 @@ public class PrerenderConfig {
     }
 
     public List<String> getExtensionsToIgnore() {
-        List<String> extensionsToIgnore = Lists.newArrayList(".js", ".css", ".less", ".png", ".jpg", ".jpeg",
+        List<String> extensionsToIgnore = Lists.newArrayList(".xml",".js", ".css", ".less", ".png", ".jpg", ".jpeg",
                 ".gif", ".pdf", ".doc", ".txt", ".zip", ".mp3", ".rar", ".exe", ".wmv", ".doc", ".avi", ".ppt", ".mpg",
                 ".mpeg", ".tif", ".wav", ".mov", ".psd", ".ai", ".xls", ".mp4", ".m4a", ".swf", ".dat", ".dmg",
                 ".iso", ".flv", ".m4v", ".torrent");


### PR DESCRIPTION
Prerender renders xmls so Google SiteMap Test Fails because it gets www.testsite.com/sitemap.xml as an html and returns "Your Sitemap appears to be an HTML page. Please use a supported sitemap format instead".
