### PR TITLE
change logging of final request url from log.trace to log.info

### DIFF
--- a/src/main/java/com/github/greengerong/PrerenderSeoService.java
+++ b/src/main/java/com/github/greengerong/PrerenderSeoService.java
@@ -331,7 +331,7 @@ public class PrerenderSeoService {
     private boolean proxyPrerenderedPageResponse(HttpServletRequest request, HttpServletResponse response)
             throws IOException, URISyntaxException {
         final String apiUrl = getApiUrl(getFullUrl(request));
-        log.trace(String.format("Prerender proxy will send request to:%s", apiUrl));
+        log.info(String.format("Prerender proxy will send request to:%s", apiUrl));
         final HttpGet getMethod = getHttpGet(apiUrl);
         copyRequestHeaders(request, getMethod);
         withPrerenderToken(getMethod);


### PR DESCRIPTION
Currently all of the non-error logging is logged at trace level. The final api request url is useful outside of specific debugging though, so this change puts it at the info level. 